### PR TITLE
Fix frag_utils.compute_distance_and_angle

### DIFF
--- a/analysis/frag_utils.py
+++ b/analysis/frag_utils.py
@@ -354,7 +354,8 @@ def compute_distance_and_angle(mol, smi_linker, smi_frags):
         frags_matches = list(mol.GetSubstructMatches(qfrag, uniquify=False))
         qlinker = Chem.AdjustQueryProperties(linker,qp)
         linker_matches = list(mol.GetSubstructMatches(qlinker, uniquify=False))
-            
+        if len(linker_matches) == 0:
+            linker_matches = [()]
         # Loop over matches
         for frag_match, linker_match in product(frags_matches, linker_matches):
             # Check if match

--- a/data/frag_utils.py
+++ b/data/frag_utils.py
@@ -352,7 +352,8 @@ def compute_distance_and_angle(mol, smi_linker, smi_frags):
         frags_matches = list(mol.GetSubstructMatches(qfrag, uniquify=False))
         qlinker = Chem.AdjustQueryProperties(linker,qp)
         linker_matches = list(mol.GetSubstructMatches(qlinker, uniquify=False))
-            
+        if len(linker_matches) == 0:
+            linker_matches = [()]
         # Loop over matches
         for frag_match, linker_match in product(frags_matches, linker_matches):
             # Check if match


### PR DESCRIPTION
This PR fixes the following bug in the preparation of fragment data.

With `rdkit>=2021.9.1`, `linker_matches` in `frag_utils.compute_distance_and_angle` with `smi_linker=""` becomes an empty list because`mol.GetSubstructMatches(Chem.MolFromSmiles(""), uniquify=False)` only returns `()`. As a result, `frag_utils.compute_distance_and_angle` with `smi_linker=""` doesn't give valid distance/angle.

